### PR TITLE
Add a simple makefile for local processing

### DIFF
--- a/makefile
+++ b/makefile
@@ -1,0 +1,7 @@
+# Used for local processing
+
+all: lint
+
+lint:
+	markdownlint --config .github/linters/.markdown-lint.yml \
+	  secure_software_development_fundamentals.md 


### PR DESCRIPTION
To ease development, create a trivial makefile so "make" will run markdownlint (you'll need that installed).

Signed-off-by: David A. Wheeler <dwheeler@dwheeler.com>