### PR TITLE
Fix Python random API names in PRNG comparison table

### DIFF
--- a/docs/lfd121.md
+++ b/docs/lfd121.md
@@ -5374,8 +5374,8 @@ Here are some examples of how to call the predictable PRNG versus a cryptographi
   </tr>
   <tr>
     <td>Python</td>
-    <td><tt>random</tt></td>
-    <td><tt>os.random</tt></td>
+    <td><tt>random.random</tt></td>
+    <td><tt>os.urandom</tt></td>
   </tr>
   <tr>
     <td>Ruby</td>


### PR DESCRIPTION
I've corrected two small errors in the Python row of the predictable vs. cryptographic PRNG comparison table in `lfd121.md`.
* `random` is just the module, `random.random` is the function.
* `os.urandom` is the correct CSPRNG function.

(I just completed your course and thought it was great. Thank you!)